### PR TITLE
优化oauth设置页面

### DIFF
--- a/src/views/oauth/index.vue
+++ b/src/views/oauth/index.vue
@@ -64,9 +64,14 @@
             >
           </el-input>
         </el-form-item>
-<!--        <el-form-item label="RedirectUrl" prop="redirect_url">
-          <el-input v-model="formData.redirect_url"></el-input>
-        </el-form-item>-->
+        <el-form-item label="RedirectUrl" prop="redirect_url">
+          <el-input
+            v-model="formData.redirect_url"
+            readonly
+            suffix-icon="el-icon-document-copy"
+            @click="copyRedirectUrl"
+          />
+        </el-form-item>
         <el-form-item label="PkceEnable" prop="pkce_enable">
           <el-switch v-model="formData.pkce_enable"
                      :active-value="true"
@@ -101,6 +106,12 @@
   import { list, create, update, detail, remove } from '@/api/oauth'
   import { ElMessage, ElMessageBox } from 'element-plus'
   import { T } from '@/utils/i18n'
+
+  const copyRedirectUrl = () => {
+    navigator.clipboard.writeText(formData.redirect_url)
+      .then(() => ElMessage.success('Copied'))
+      .catch(() => ElMessage.error('Copy failed'))
+  }
 
   const listRes = reactive({
     list: [], total: 0, loading: false,
@@ -172,7 +183,7 @@
   const rules = {
     client_id: [{ required: true, message: T('ParamRequired', { param: 'client_id' }), trigger: 'blur' }],
     client_secret: [{ required: true, message: T('ParamRequired', { param: 'client_secret' }), trigger: 'blur' }],
-    redirect_url: [{ required: true, message: T('ParamRequired', { param: 'redirect_url' }), trigger: 'blur' }],
+    // redirect_url: [{ required: true, message: T('ParamRequired', { param: 'redirect_url' }), trigger: 'blur' }],
     oauth_type: [{ required: true, message: T('ParamRequired', { param: 'oauth_type' }), trigger: 'blur' }],
     issuer: [{ required: true, message: T('ParamRequired', { param: 'issuer' }), trigger: 'blur' }],
     pkce_method: [
@@ -190,6 +201,11 @@
       },
     ],
   }
+
+  const defaultRedirect = () => {
+  return `${window.location.origin}/api/oidc/callback`
+}
+
   const toEdit = (row) => {
     formVisible.value = true
     formData.id = row.id
@@ -198,7 +214,7 @@
     formData.issuer = row.issuer
     formData.client_id = row.client_id
     formData.client_secret = row.client_secret
-    formData.redirect_url = row.redirect_url
+    formData.redirect_url = row.redirect_url || defaultRedirect()
     formData.scopes = row.scopes
     formData.auto_register = row.auto_register
     formData.pkce_enable = row.pkce_enable
@@ -212,7 +228,7 @@
     formData.issuer = ''
     formData.client_id = ''
     formData.client_secret = ''
-    formData.redirect_url = ''
+    formData.redirect_url = defaultRedirect()
     formData.scopes = ''
     formData.auto_register = false
     formData.pkce_enable = false

--- a/src/views/oauth/index.vue
+++ b/src/views/oauth/index.vue
@@ -37,7 +37,7 @@
     </el-card>
     <el-dialog v-model="formVisible" :title="!formData.id?T('Create') :T('Update')" width="800">
       <el-form class="dialog-form" ref="form" :model="formData" :rules="rules" label-width="120px">
-        <el-form-item label="Type" prop="">
+        <el-form-item label="Type" prop="oauth_type">
           <el-radio-group v-model="formData.oauth_type" :disabled="!!formData.id">
             <el-radio v-for="item in types" :key="item.value" :value="item.value" style="display: block">
               {{ item.label }}
@@ -57,7 +57,12 @@
           <el-input v-model="formData.client_id"></el-input>
         </el-form-item>
         <el-form-item label="ClientSecret" prop="client_secret">
-          <el-input v-model="formData.client_secret"></el-input>
+          <el-input
+            v-model="formData.client_secret"
+            :type="formData.id ? 'password' : 'text'"
+            :show-password="!formData.id"
+            >
+          </el-input>
         </el-form-item>
 <!--        <el-form-item label="RedirectUrl" prop="redirect_url">
           <el-input v-model="formData.redirect_url"></el-input>


### PR DESCRIPTION
1. 在修改ClientSecret的时候，隐藏
2. 在oauth Form上。显示redirect url(目前是从浏览器读取的host，也许我们应该从后端返回？实时生成，但是不存在数据库中)

<img width="804" height="442" alt="image" src="https://github.com/user-attachments/assets/9c714b7f-7f50-4d30-a9cc-6693a91764be" />
